### PR TITLE
Included a missing 'break'

### DIFF
--- a/Classes/CGLMailHelper.m
+++ b/Classes/CGLMailHelper.m
@@ -133,6 +133,7 @@
             break;
         case MFMailComposeResultFailed:
             desc = @"Failed";
+            break;
         default:
             desc = @"Unknown";
             break;


### PR DESCRIPTION
Included a missing ‘break’ for descriptionForResult method
